### PR TITLE
Add core engine and educational skeleton

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "euskal-ikastetxea",
+  "version": "0.1.0",
+  "type": "module"
+}

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,12 @@
+{
+  "name": "Euskal Ikastetxea",
+  "short_name": "Ikastetxea",
+  "theme_color": "#00A86B",
+  "start_url": "/",
+  "display": "standalone",
+  "description": "Basque language learning game",
+  "icons": [
+    { "src": "/icons/icon-192.png", "sizes": "192x192", "type": "image/png" },
+    { "src": "/icons/icon-512.png", "sizes": "512x512", "type": "image/png" }
+  ]
+}

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,0 +1,19 @@
+const CACHE = 'ikastetxea-v1';
+const ASSETS = [
+  '/',
+  '/public/manifest.json'
+];
+
+self.addEventListener('install', e => {
+  e.waitUntil(caches.open(CACHE).then(c => c.addAll(ASSETS)));
+});
+
+self.addEventListener('activate', e => {
+  e.waitUntil(caches.keys().then(keys => Promise.all(keys.filter(k => k !== CACHE).map(k => caches.delete(k)))));
+});
+
+self.addEventListener('fetch', e => {
+  e.respondWith(
+    caches.match(e.request).then(res => res || fetch(e.request))
+  );
+});

--- a/src/audio/AudioManager.js
+++ b/src/audio/AudioManager.js
@@ -1,0 +1,48 @@
+class AudioManager {
+  constructor() {
+    this.ctx = new (window.AudioContext || window.webkitAudioContext)();
+    this.buffers = new Map();
+    this.musicSource = null;
+    this.volumes = { music: 0.5, sfx: 1 };
+  }
+
+  loadAudio(key, arrayBuffer) {
+    return this.ctx.decodeAudioData(arrayBuffer).then(buf => {
+      this.buffers.set(key, buf);
+      return buf;
+    });
+  }
+
+  playMusic(key) {
+    this.stopMusic();
+    const src = this.ctx.createBufferSource();
+    src.buffer = this.buffers.get(key);
+    src.loop = true;
+    const gain = this.ctx.createGain();
+    gain.gain.value = this.volumes.music;
+    src.connect(gain).connect(this.ctx.destination);
+    src.start(0);
+    this.musicSource = src;
+  }
+
+  stopMusic() {
+    this.musicSource?.stop();
+    this.musicSource = null;
+  }
+
+  playSFX(key) {
+    const src = this.ctx.createBufferSource();
+    src.buffer = this.buffers.get(key);
+    const gain = this.ctx.createGain();
+    gain.gain.value = this.volumes.sfx;
+    src.connect(gain).connect(this.ctx.destination);
+    src.start(0);
+  }
+
+  playEuskeraWord(key) {
+    this.playSFX(key);
+  }
+}
+
+const audio = new AudioManager();
+export default audio;

--- a/src/characters/NPCManager.js
+++ b/src/characters/NPCManager.js
@@ -1,0 +1,43 @@
+import AssetLoader from '../core/AssetLoader.js';
+import EventManager, { Events } from '../events/EventManager.js';
+import DialogueEngine from '../dialogue/DialogueEngine.js';
+import { DialogueComponent, LessonComponent, PatrolComponent } from './components/NPCComponent.js';
+
+class NPC {
+  constructor(def) {
+    this.pos = { x: def.x, y: def.y };
+    this.components = [];
+    if (def.dialogue) this.components.push(new DialogueComponent(def.dialogue));
+    if (def.lesson) this.components.push(new LessonComponent(def.lesson));
+    if (def.patrol) this.components.push(new PatrolComponent(def.patrol));
+  }
+
+  update(dt) {
+    this.components.forEach(c => c.update?.(dt));
+  }
+
+  render(ctx) {
+    // draw sprite placeholder
+  }
+}
+
+class NPCManager {
+  constructor() {
+    this.npcs = [];
+  }
+
+  load(defs) {
+    this.npcs = defs.map(d => new NPC(d));
+  }
+
+  update(dt) {
+    this.npcs.forEach(n => n.update(dt));
+  }
+
+  render(ctx) {
+    this.npcs.forEach(n => n.render(ctx));
+  }
+}
+
+const manager = new NPCManager();
+export default manager;

--- a/src/characters/PlayerController.js
+++ b/src/characters/PlayerController.js
@@ -1,0 +1,42 @@
+import EventManager, { Events } from '../events/EventManager.js';
+import CollisionSystem from '../world/CollisionSystem.js';
+import SpriteAnimator from '../graphics/SpriteAnimator.js';
+
+class PlayerController {
+  constructor(sprite) {
+    this.pos = { x: 0, y: 0 };
+    this.animator = new SpriteAnimator(sprite);
+    this.enabled = true;
+    EventManager.subscribe(Events.DIALOGUE_STARTED, () => this.enabled = false);
+    EventManager.subscribe(Events.QUIZ_STARTED, () => this.enabled = false);
+    EventManager.subscribe(Events.DIALOGUE_FINISHED, () => this.enabled = true);
+    EventManager.subscribe(Events.RESUME_GAME, () => this.enabled = true);
+    window.addEventListener('keydown', e => this.handleInput(e));
+  }
+
+  handleInput(e) {
+    if (!this.enabled) return;
+    const dir = { x: 0, y: 0 };
+    if (e.key === 'ArrowUp') dir.y = -16;
+    if (e.key === 'ArrowDown') dir.y = 16;
+    if (e.key === 'ArrowLeft') dir.x = -16;
+    if (e.key === 'ArrowRight') dir.x = 16;
+    if (dir.x || dir.y) {
+      const newPos = CollisionSystem.resolveMovement(this.pos, dir);
+      if (newPos !== this.pos) {
+        this.pos = newPos;
+        EventManager.emit(Events.PLAYER_MOVED, { pos: this.pos });
+      }
+    }
+  }
+
+  update(dt) {
+    this.animator.update(dt);
+  }
+
+  render(ctx) {
+    this.animator.render(ctx, this.pos.x, this.pos.y);
+  }
+}
+
+export default PlayerController;

--- a/src/characters/components/NPCComponent.js
+++ b/src/characters/components/NPCComponent.js
@@ -1,0 +1,38 @@
+import EventManager, { Events } from '../../events/EventManager.js';
+
+export class NPCComponent {
+  constructor() {}
+  update() {}
+}
+
+export class DialogueComponent extends NPCComponent {
+  constructor(dialogueId) {
+    super();
+    this.dialogueId = dialogueId;
+  }
+  trigger() {
+    EventManager.emit(Events.DIALOGUE_STARTED, this.dialogueId);
+  }
+}
+
+export class LessonComponent extends NPCComponent {
+  constructor(lessonId) {
+    super();
+    this.lessonId = lessonId;
+  }
+  trigger() {
+    EventManager.emit(Events.LESSON_COMPLETED, { lesson: this.lessonId });
+  }
+}
+
+export class PatrolComponent extends NPCComponent {
+  constructor(path) {
+    super();
+    this.path = path;
+    this.index = 0;
+  }
+  update() {
+    // simple loop
+    this.index = (this.index + 1) % this.path.length;
+  }
+}

--- a/src/core/AssetLoader.js
+++ b/src/core/AssetLoader.js
@@ -1,0 +1,59 @@
+import EventManager, { Events } from '../events/EventManager.js';
+
+class AssetLoader {
+  constructor() {
+    this.images = new Map();
+    this.audio = new Map();
+    this.json = new Map();
+  }
+
+  loadImage(key, src) {
+    return new Promise((resolve, reject) => {
+      const img = new Image();
+      img.onload = () => {
+        this.images.set(key, img);
+        EventManager.emit(Events.ASSET_LOADED, { type: 'image', key });
+        resolve(img);
+      };
+      img.onerror = reject;
+      img.src = src;
+    });
+  }
+
+  loadAudio(key, src) {
+    return fetch(src)
+      .then(r => r.arrayBuffer())
+      .then(buf => {
+        this.audio.set(key, buf);
+        EventManager.emit(Events.ASSET_LOADED, { type: 'audio', key });
+        return buf;
+      });
+  }
+
+  loadJSON(key, src) {
+    return fetch(src)
+      .then(r => r.json())
+      .then(data => {
+        this.json.set(key, data);
+        EventManager.emit(Events.ASSET_LOADED, { type: 'json', key });
+        return data;
+      });
+  }
+
+  loadAll(manifest) {
+    const promises = [];
+    manifest.images?.forEach(i => promises.push(this.loadImage(i.key, i.src)));
+    manifest.audio?.forEach(a => promises.push(this.loadAudio(a.key, a.src)));
+    manifest.json?.forEach(j => promises.push(this.loadJSON(j.key, j.src)));
+    return Promise.all(promises).then(() => {
+      EventManager.emit(Events.ASSETS_COMPLETE);
+    });
+  }
+
+  getImage(key) { return this.images.get(key); }
+  getAudio(key) { return this.audio.get(key); }
+  getJSON(key) { return this.json.get(key); }
+}
+
+const loader = new AssetLoader();
+export default loader;

--- a/src/core/GameEngine.js
+++ b/src/core/GameEngine.js
@@ -1,0 +1,42 @@
+import EventManager, { Events } from '../events/EventManager.js';
+import AssetLoader from './AssetLoader.js';
+import SaveManager from './SaveManager.js';
+import SceneManager from '../scenes/SceneManager.js';
+import { scaleCanvas } from '../utils/ResponsiveScaler.js';
+
+const GRID_SIZE = 16;
+
+export default class GameEngine {
+  constructor() {
+    this.canvas = document.createElement('canvas');
+    this.canvas.width = 240;
+    this.canvas.height = 160;
+    document.body.appendChild(this.canvas);
+    scaleCanvas(this.canvas);
+
+    this.ctx = this.canvas.getContext('2d');
+    this.lastTime = 0;
+    this.paused = false;
+
+    EventManager.subscribe(Events.PAUSE_GAME, () => this.paused = true);
+    EventManager.subscribe(Events.RESUME_GAME, () => this.paused = false);
+    window.addEventListener('resize', () => scaleCanvas(this.canvas));
+  }
+
+  start(manifest) {
+    AssetLoader.loadAll(manifest).then(() => {
+      this.loop(0);
+    });
+  }
+
+  loop(time) {
+    requestAnimationFrame(t => this.loop(t));
+    const dt = time - this.lastTime;
+    if (!this.paused) {
+      SceneManager.update(dt);
+      SceneManager.render(this.ctx);
+      EventManager.emit(Events.FRAME_TICK, { dt });
+    }
+    this.lastTime = time;
+  }
+}

--- a/src/core/SaveManager.js
+++ b/src/core/SaveManager.js
@@ -1,0 +1,40 @@
+import EventManager, { Events } from '../events/EventManager.js';
+
+const STORAGE_KEY = 'euskal_save';
+
+class SaveManager {
+  constructor() {
+    EventManager.subscribe(Events.LESSON_COMPLETED, () => this.autoSave());
+    EventManager.subscribe(Events.QUIZ_COMPLETED, () => this.autoSave());
+  }
+
+  saveGame(data) {
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+    } catch (e) {
+      console.error('Save failed', e);
+    }
+  }
+
+  loadGame() {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      return raw ? JSON.parse(raw) : null;
+    } catch (e) {
+      console.error('Load failed', e);
+      return null;
+    }
+  }
+
+  deleteSave() {
+    localStorage.removeItem(STORAGE_KEY);
+  }
+
+  autoSave() {
+    const current = this.loadGame() || {};
+    this.saveGame(current);
+  }
+}
+
+const instance = new SaveManager();
+export default instance;

--- a/src/dialogue/DialogueEngine.js
+++ b/src/dialogue/DialogueEngine.js
@@ -1,0 +1,49 @@
+import EventManager, { Events } from '../events/EventManager.js';
+import DialogueBox from '../ui/DialogueBox.js';
+import ContentDatabase from '../education/ContentDatabase.js';
+
+class DialogueEngine {
+  constructor() {
+    this.active = null;
+    this.index = 0;
+    this.box = new DialogueBox();
+  }
+
+  startDialogue(id) {
+    this.active = ContentDatabase.getDialogue(id);
+    this.index = 0;
+    this.box.open();
+    this.showLine();
+    EventManager.emit(Events.DIALOGUE_STARTED, id);
+  }
+
+  showLine() {
+    if (!this.active) return;
+    const line = this.active.lines[this.index];
+    if (!line) {
+      this.end();
+    } else {
+      this.box.setText(line.text, line.translation);
+    }
+  }
+
+  advance() {
+    this.index++;
+    this.showLine();
+  }
+
+  chooseOption(i) {
+    const opt = this.active.options[i];
+    if (opt.quiz) EventManager.emit(Events.QUIZ_TRIGGER, opt.quiz);
+    this.end();
+  }
+
+  end() {
+    this.active = null;
+    this.box.close();
+    EventManager.emit(Events.DIALOGUE_FINISHED);
+  }
+}
+
+const engine = new DialogueEngine();
+export default engine;

--- a/src/education/ContentDatabase.js
+++ b/src/education/ContentDatabase.js
@@ -1,0 +1,32 @@
+import AssetLoader from '../core/AssetLoader.js';
+import EventManager, { Events } from '../events/EventManager.js';
+
+class ContentDatabase {
+  constructor() {
+    this.data = {};
+  }
+
+  async load(manifest) {
+    const promises = manifest.map(m => AssetLoader.loadJSON(m.key, m.src));
+    await Promise.all(promises);
+    manifest.forEach(m => {
+      this.data[m.key] = AssetLoader.getJSON(m.key);
+    });
+    EventManager.emit('CONTENT_LOADED');
+  }
+
+  getVocabulary(topic) {
+    return this.data.vocab?.[topic] || [];
+  }
+
+  getDialogue(id) {
+    return this.data.dialogues?.[id] || null;
+  }
+
+  getQuiz(id) {
+    return this.data.quizzes?.[id] || null;
+  }
+}
+
+const db = new ContentDatabase();
+export default db;

--- a/src/education/LessonManager.js
+++ b/src/education/LessonManager.js
@@ -1,0 +1,26 @@
+import EventManager, { Events } from '../events/EventManager.js';
+import ContentDatabase from './ContentDatabase.js';
+import ProgressTracker from './ProgressTracker.js';
+
+class LessonManager {
+  constructor() {
+    this.active = null;
+  }
+
+  startLesson(id) {
+    this.active = ContentDatabase.getVocabulary(id);
+  }
+
+  completeLesson(id) {
+    ProgressTracker.recordLesson(id);
+    EventManager.emit(Events.LESSON_COMPLETED, { lesson: id });
+    this.active = null;
+  }
+
+  getAvailableLessons() {
+    return Object.keys(ContentDatabase.data.vocab || {});
+  }
+}
+
+const manager = new LessonManager();
+export default manager;

--- a/src/education/ProgressTracker.js
+++ b/src/education/ProgressTracker.js
@@ -1,0 +1,35 @@
+import SaveManager from '../core/SaveManager.js';
+import EventManager, { Events } from '../events/EventManager.js';
+
+class ProgressTracker {
+  constructor() {
+    this.data = { xp: 0, level: 1, lessons: [], vocab: [] };
+    const saved = SaveManager.loadGame();
+    if (saved?.progress) this.data = saved.progress;
+    EventManager.subscribe(Events.LESSON_COMPLETED, e => this.recordLesson(e.lesson));
+    EventManager.subscribe(Events.QUIZ_COMPLETED, e => this.addXP(e.score));
+  }
+
+  recordLesson(id) {
+    if (!this.data.lessons.includes(id)) this.data.lessons.push(id);
+    this.persist();
+  }
+
+  addXP(xp) {
+    this.data.xp += xp;
+    if (this.data.xp > this.data.level * 100) {
+      this.data.level++;
+      EventManager.emit(Events.LEVEL_UP, { level: this.data.level });
+    }
+    this.persist();
+  }
+
+  persist() {
+    const save = SaveManager.loadGame() || {};
+    save.progress = this.data;
+    SaveManager.saveGame(save);
+  }
+}
+
+const tracker = new ProgressTracker();
+export default tracker;

--- a/src/education/QuizSystem.js
+++ b/src/education/QuizSystem.js
@@ -1,0 +1,34 @@
+import ContentDatabase from './ContentDatabase.js';
+import EventManager, { Events } from '../events/EventManager.js';
+import AudioManager from '../audio/AudioManager.js';
+
+class QuizSystem {
+  constructor() {
+    this.active = null;
+    this.score = 0;
+  }
+
+  startQuiz(id) {
+    this.active = ContentDatabase.getQuiz(id);
+    this.score = 0;
+    EventManager.emit(Events.QUIZ_STARTED, id);
+  }
+
+  submitAnswer(answer) {
+    const q = this.active.questions[this.active.index];
+    if (q.correct === answer) this.score += 10;
+    if (q.audio) AudioManager.playEuskeraWord(q.audio);
+    this.active.index++;
+    if (this.active.index >= this.active.questions.length) {
+      this.endQuiz();
+    }
+  }
+
+  endQuiz() {
+    EventManager.emit(Events.QUIZ_COMPLETED, { score: this.score });
+    this.active = null;
+  }
+}
+
+const quiz = new QuizSystem();
+export default quiz;

--- a/src/education/RewardSystem.js
+++ b/src/education/RewardSystem.js
@@ -1,0 +1,18 @@
+import EventManager, { Events } from '../events/EventManager.js';
+import ProgressTracker from './ProgressTracker.js';
+
+class RewardSystem {
+  constructor() {
+    EventManager.subscribe(Events.LESSON_COMPLETED, e => this.award('badge', e.lesson));
+    EventManager.subscribe(Events.QUIZ_COMPLETED, e => this.award('xp', e.score));
+    EventManager.subscribe(Events.LEVEL_UP, e => this.award('level', e.level));
+  }
+
+  award(type, data) {
+    // placeholder for reward logic
+    console.log('Reward', type, data);
+  }
+}
+
+const rewards = new RewardSystem();
+export default rewards;

--- a/src/events/EventManager.js
+++ b/src/events/EventManager.js
@@ -1,0 +1,55 @@
+// Simple event bus singleton for decoupled communication
+class EventManager {
+  constructor() {
+    this.listeners = new Map();
+  }
+
+  subscribe(event, callback) {
+    if (!this.listeners.has(event)) {
+      this.listeners.set(event, new Set());
+    }
+    this.listeners.get(event).add(callback);
+  }
+
+  unsubscribe(event, callback) {
+    const set = this.listeners.get(event);
+    if (set) {
+      set.delete(callback);
+    }
+  }
+
+  emit(event, payload) {
+    const set = this.listeners.get(event);
+    if (set) {
+      for (const cb of set) {
+        try {
+          cb(payload);
+        } catch (err) {
+          console.error('Event handler error', err);
+        }
+      }
+    }
+  }
+}
+
+export const Events = {
+  FRAME_TICK: 'FRAME_TICK',
+  PAUSE_GAME: 'PAUSE_GAME',
+  RESUME_GAME: 'RESUME_GAME',
+  ASSET_LOADED: 'ASSET_LOADED',
+  ASSETS_COMPLETE: 'ASSETS_COMPLETE',
+  LESSON_COMPLETED: 'LESSON_COMPLETED',
+  QUIZ_COMPLETED: 'QUIZ_COMPLETED',
+  QUIZ_STARTED: 'QUIZ_STARTED',
+  DIALOGUE_STARTED: 'DIALOGUE_STARTED',
+  DIALOGUE_FINISHED: 'DIALOGUE_FINISHED',
+  AREA_ENTERED: 'AREA_ENTERED',
+  PLAYER_ENTER_WARP: 'PLAYER_ENTER_WARP',
+  PLAYER_MOVED: 'PLAYER_MOVED',
+  VOCABULARY_LEARNED: 'VOCABULARY_LEARNED',
+  LEVEL_UP: 'LEVEL_UP',
+  QUIZ_TRIGGER: 'QUIZ_TRIGGER'
+};
+
+const instance = new EventManager();
+export default instance;

--- a/src/graphics/SpriteAnimator.js
+++ b/src/graphics/SpriteAnimator.js
@@ -1,0 +1,26 @@
+class SpriteAnimator {
+  constructor(sprite, frameTime = 150) {
+    this.sprite = sprite;
+    this.frameTime = frameTime;
+    this.elapsed = 0;
+    this.frame = 0;
+  }
+
+  update(dt) {
+    this.elapsed += dt;
+    if (this.elapsed >= this.frameTime) {
+      this.elapsed = 0;
+      this.frame = (this.frame + 1) % 4; // 4-frame cycles
+    }
+  }
+
+  render(ctx, x, y) {
+    ctx.drawImage(this.sprite, this.frame * 16, 0, 16, 16, x, y, 16, 16);
+  }
+
+  triggerAnimation(name) {
+    // placeholder for highlight animations
+  }
+}
+
+export default SpriteAnimator;

--- a/src/input/TouchControls.js
+++ b/src/input/TouchControls.js
@@ -1,0 +1,24 @@
+import EventManager, { Events } from '../events/EventManager.js';
+
+class TouchControls {
+  constructor() {
+    this.enabled = 'ontouchstart' in window;
+    if (!this.enabled) return;
+    this.root = document.createElement('div');
+    this.root.id = 'touch-controls';
+    document.body.appendChild(this.root);
+    this.root.addEventListener('touchstart', e => this.handle(e));
+  }
+
+  handle(e) {
+    const dir = e.target.dataset.dir;
+    if (dir) {
+      EventManager.emit('TOUCH_DIR', dir);
+    }
+    if (e.target.dataset.action === 'hint') {
+      EventManager.emit('HINT_REQUEST');
+    }
+  }
+}
+
+export default TouchControls;

--- a/src/scenes/SceneManager.js
+++ b/src/scenes/SceneManager.js
@@ -1,0 +1,32 @@
+import EventManager, { Events } from '../events/EventManager.js';
+import TransitionManager from '../world/TransitionManager.js';
+
+class SceneManager {
+  constructor() {
+    this.scenes = new Map();
+    this.active = null;
+  }
+
+  registerScene(name, scene) {
+    this.scenes.set(name, scene);
+  }
+
+  switchTo(name, data) {
+    const next = this.scenes.get(name);
+    if (!next) throw new Error('Scene not found: ' + name);
+    if (this.active && this.active.onExit) this.active.onExit();
+    this.active = new next(data);
+    if (this.active.onEnter) this.active.onEnter(data);
+  }
+
+  update(dt) {
+    this.active?.update?.(dt);
+  }
+
+  render(ctx) {
+    this.active?.render?.(ctx);
+  }
+}
+
+const manager = new SceneManager();
+export default manager;

--- a/src/state/StateManager.js
+++ b/src/state/StateManager.js
@@ -1,0 +1,35 @@
+import EventManager, { Events } from '../events/EventManager.js';
+
+export const States = {
+  TITLE: 'TITLE',
+  WORLD: 'WORLD',
+  DIALOGUE: 'DIALOGUE',
+  QUIZ: 'QUIZ',
+  MENU: 'MENU'
+};
+
+class StateManager {
+  constructor() {
+    this.stack = [];
+  }
+
+  pushState(state) {
+    this.stack.push(state);
+    EventManager.emit(Events.PAUSE_GAME);
+  }
+
+  popState() {
+    const state = this.stack.pop();
+    if (this.stack.length === 0) {
+      EventManager.emit(Events.RESUME_GAME);
+    }
+    return state;
+  }
+
+  currentState() {
+    return this.stack[this.stack.length - 1];
+  }
+}
+
+const manager = new StateManager();
+export default manager;

--- a/src/ui/DialogueBox.js
+++ b/src/ui/DialogueBox.js
@@ -1,0 +1,27 @@
+import AudioManager from '../audio/AudioManager.js';
+
+class DialogueBox {
+  constructor() {
+    this.opened = false;
+    this.text = '';
+    this.translation = '';
+    this.speed = 30;
+    this.index = 0;
+  }
+
+  open() { this.opened = true; this.index = 0; }
+  close() { this.opened = false; }
+  setText(t, tr) { this.text = t; this.translation = tr; this.index = 0; }
+
+  draw(ctx) {
+    if (!this.opened) return;
+    ctx.fillStyle = 'rgba(0,0,0,0.7)';
+    ctx.fillRect(0, 112, 240, 48);
+    ctx.fillStyle = '#fff';
+    const shown = this.text.slice(0, this.index);
+    ctx.fillText(shown, 10, 130);
+    if (this.index < this.text.length) this.index += 1;
+  }
+}
+
+export default DialogueBox;

--- a/src/ui/HUD.js
+++ b/src/ui/HUD.js
@@ -1,0 +1,19 @@
+import EventManager, { Events } from '../events/EventManager.js';
+import ProgressTracker from '../education/ProgressTracker.js';
+
+class HUD {
+  constructor() {
+    this.lesson = '';
+    EventManager.subscribe(Events.LESSON_COMPLETED, e => this.lesson = '');
+    EventManager.subscribe(Events.VOCABULARY_LEARNED, e => this.lesson = e.word);
+  }
+
+  render(ctx) {
+    ctx.fillStyle = '#fff';
+    ctx.fillText('XP: ' + ProgressTracker.data.xp, 5, 10);
+    if (this.lesson) ctx.fillText('Word: ' + this.lesson, 5, 20);
+  }
+}
+
+const hud = new HUD();
+export default hud;

--- a/src/ui/MenuSystem.js
+++ b/src/ui/MenuSystem.js
@@ -1,0 +1,34 @@
+import EventManager from '../events/EventManager.js';
+import StateManager, { States } from '../state/StateManager.js';
+import ProgressTracker from '../education/ProgressTracker.js';
+
+class MenuSystem {
+  constructor() {
+    this.activeMenu = null;
+  }
+
+  open(menu) {
+    this.activeMenu = menu;
+    StateManager.pushState(States.MENU);
+  }
+
+  close() {
+    this.activeMenu = null;
+    StateManager.popState();
+  }
+
+  render(ctx) {
+    if (!this.activeMenu) return;
+    ctx.fillStyle = '#000';
+    ctx.fillRect(0, 0, 240, 160);
+    ctx.fillStyle = '#fff';
+    if (this.activeMenu === 'Progress') {
+      ctx.fillText('Level: ' + ProgressTracker.data.level, 20, 20);
+    } else {
+      ctx.fillText(this.activeMenu, 20, 20);
+    }
+  }
+}
+
+const menu = new MenuSystem();
+export default menu;

--- a/src/utils/ResponsiveScaler.js
+++ b/src/utils/ResponsiveScaler.js
@@ -1,0 +1,7 @@
+export function scaleCanvas(canvas) {
+  const width = 240;
+  const height = 160;
+  const scale = Math.floor(Math.min(window.innerWidth / width, window.innerHeight / height));
+  canvas.style.width = width * scale + 'px';
+  canvas.style.height = height * scale + 'px';
+}

--- a/src/world/CollisionSystem.js
+++ b/src/world/CollisionSystem.js
@@ -1,0 +1,21 @@
+import MapManager from './MapManager.js';
+import EventManager, { Events } from '../events/EventManager.js';
+
+class CollisionSystem {
+  checkCollision(x, y) {
+    const layer = MapManager.current.layers?.find(l => l.name === 'Collision');
+    if (!layer) return false;
+    const tile = MapManager.getTile(x, y, 'Collision');
+    return tile !== 0;
+  }
+
+  resolveMovement(pos, dir) {
+    const nx = pos.x + dir.x;
+    const ny = pos.y + dir.y;
+    if (this.checkCollision(nx, ny)) return pos;
+    return { x: nx, y: ny };
+  }
+}
+
+const system = new CollisionSystem();
+export default system;

--- a/src/world/MapManager.js
+++ b/src/world/MapManager.js
@@ -1,0 +1,28 @@
+import AssetLoader from '../core/AssetLoader.js';
+import EventManager, { Events } from '../events/EventManager.js';
+
+class MapManager {
+  constructor() {
+    this.current = null;
+    this.warps = [];
+  }
+
+  load(name, src) {
+    return AssetLoader.loadJSON(name, src).then(data => {
+      this.current = data;
+      this.warps = data.layers?.find(l => l.name === 'Warps')?.objects || [];
+      EventManager.emit(Events.AREA_ENTERED, { area: name });
+      return data;
+    });
+  }
+
+  getTile(x, y, layerName) {
+    const layer = this.current.layers?.find(l => l.name === layerName);
+    if (!layer) return 0;
+    const index = y * layer.width + x;
+    return layer.data[index];
+  }
+}
+
+const manager = new MapManager();
+export default manager;

--- a/src/world/TileEngine.js
+++ b/src/world/TileEngine.js
@@ -1,0 +1,37 @@
+import MapManager from './MapManager.js';
+
+class TileEngine {
+  constructor(ctx) {
+    this.ctx = ctx;
+    this.camera = { x: 0, y: 0 };
+  }
+
+  drawLayer(layer) {
+    const tileSize = 16;
+    const tileset = MapManager.current.tilesets[0];
+    const image = document.createElement('img');
+    image.src = tileset.image; // assume loaded elsewhere
+    const cols = tileset.columns;
+    for (let y = 0; y < layer.height; y++) {
+      for (let x = 0; x < layer.width; x++) {
+        const index = y * layer.width + x;
+        const id = layer.data[index];
+        if (id === 0) continue;
+        const sx = ((id - 1) % cols) * tileSize;
+        const sy = Math.floor((id - 1) / cols) * tileSize;
+        this.ctx.drawImage(image, sx, sy, tileSize, tileSize, x * tileSize - this.camera.x, y * tileSize - this.camera.y, tileSize, tileSize);
+      }
+    }
+  }
+
+  render() {
+    MapManager.current.layers?.filter(l => l.type === 'tilelayer').forEach(l => this.drawLayer(l));
+  }
+
+  centerOn(x, y) {
+    this.camera.x = x - 120; // half of 240
+    this.camera.y = y - 80;  // half of 160
+  }
+}
+
+export default TileEngine;

--- a/src/world/TransitionManager.js
+++ b/src/world/TransitionManager.js
@@ -1,0 +1,25 @@
+import EventManager, { Events } from '../events/EventManager.js';
+import MapManager from './MapManager.js';
+import SceneManager from '../scenes/SceneManager.js';
+
+class TransitionManager {
+  constructor() {
+    EventManager.subscribe(Events.PLAYER_ENTER_WARP, warp => this.handleWarp(warp));
+  }
+
+  fade(cb) {
+    // simplistic fade using CSS class
+    cb();
+  }
+
+  handleWarp(warp) {
+    this.fade(() => {
+      MapManager.load(warp.target, warp.map).then(() => {
+        if (warp.scene) SceneManager.switchTo(warp.scene, warp.data);
+      });
+    });
+  }
+}
+
+const manager = new TransitionManager();
+export default manager;


### PR DESCRIPTION
## Summary
- Implement modular game engine with event bus, asset loading, save management, scenes, state, and world systems.
- Add educational components including lessons, quizzes, progress tracking, and rewards.
- Provide UI, audio, input, and PWA support with manifest and service worker.

## Testing
- `node -e "import('./src/core/GameEngine.js').then(m=>console.log('GameEngine loaded'))"`
- `node -e "import('./src/education/QuizSystem.js').then(()=>console.log('Quiz loaded'))"` *(fails: ReferenceError: window is not defined)*


------
https://chatgpt.com/codex/tasks/task_e_68c6bfd634c4832db6af4bf0339aa134