### PR TITLE
Add main entry point and start script

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,0 +1,11 @@
+import GameEngine from './src/core/GameEngine.js';
+
+const game = new GameEngine();
+
+const assetManifest = {};
+
+async function main() {
+  await game.start(assetManifest);
+}
+
+main();

--- a/package.json
+++ b/package.json
@@ -1,5 +1,8 @@
 {
   "name": "euskal-ikastetxea",
   "version": "0.1.0",
-  "type": "module"
+  "type": "module",
+  "scripts": {
+    "start": "node main.js"
+  }
 }


### PR DESCRIPTION
## Summary
- Add `main.js` entry point that starts the `GameEngine`.
- Define npm `start` script to run the entry point with Node.

## Testing
- `npm test` (fails: Missing script "test")
- `npm start` (fails: ReferenceError: document is not defined)


------
https://chatgpt.com/codex/tasks/task_e_68c6c8610a7c832da8bcca44efbac3da