### PR TITLE
Add cache limits and tile culling

### DIFF
--- a/src/core/AssetLoader.js
+++ b/src/core/AssetLoader.js
@@ -1,8 +1,31 @@
 class AssetLoader {
-  constructor() {
+  constructor({
+    maxImages = 100,
+    maxAudio = 20,
+    maxJSON = 100,
+  } = {}) {
     this.imageCache = new Map();
     this.audioCache = new Map();
     this.jsonCache = new Map();
+
+    this.maxImages = maxImages;
+    this.maxAudio = maxAudio;
+    this.maxJSON = maxJSON;
+  }
+
+  _enforceLimit(cache, max) {
+    while (cache.size > max) {
+      const oldestKey = cache.keys().next().value;
+      const asset = cache.get(oldestKey);
+
+      // Release audio buffers explicitly
+      if (asset instanceof HTMLAudioElement) {
+        asset.pause();
+        asset.src = '';
+      }
+
+      cache.delete(oldestKey);
+    }
   }
 
   loadImages(paths = []) {
@@ -15,9 +38,16 @@ class AssetLoader {
     return Promise.all(promises);
   }
 
-  loadJSON(paths = []) {
-    const promises = paths.map(p => this._loadJSON(p));
-    return Promise.all(promises);
+  loadJSON(pathsOrKey, maybePath) {
+    if (Array.isArray(pathsOrKey)) {
+      const promises = pathsOrKey.map(p => this._loadJSON(p));
+      return Promise.all(promises);
+    }
+
+    // Support calling with (key, path) for custom cache keys
+    const key = maybePath ? pathsOrKey : pathsOrKey;
+    const path = maybePath || pathsOrKey;
+    return this._loadJSON(path, key);
   }
 
   _loadImage(path) {
@@ -28,6 +58,7 @@ class AssetLoader {
       const img = new Image();
       img.onload = () => {
         this.imageCache.set(path, img);
+        this._enforceLimit(this.imageCache, this.maxImages);
         resolve(img);
       };
       img.onerror = reject;
@@ -43,6 +74,7 @@ class AssetLoader {
       const audio = new Audio();
       audio.addEventListener('canplaythrough', () => {
         this.audioCache.set(path, audio);
+        this._enforceLimit(this.audioCache, this.maxAudio);
         resolve(audio);
       }, { once: true });
       audio.addEventListener('error', reject, { once: true });
@@ -51,14 +83,15 @@ class AssetLoader {
     });
   }
 
-  _loadJSON(path) {
-    if (this.jsonCache.has(path)) {
-      return Promise.resolve(this.jsonCache.get(path));
+  _loadJSON(path, key = path) {
+    if (this.jsonCache.has(key)) {
+      return Promise.resolve(this.jsonCache.get(key));
     }
     return fetch(path)
       .then(r => r.json())
       .then(data => {
-        this.jsonCache.set(path, data);
+        this.jsonCache.set(key, data);
+        this._enforceLimit(this.jsonCache, this.maxJSON);
         return data;
       });
   }
@@ -73,6 +106,26 @@ class AssetLoader {
 
   getJSON(path) {
     return this.jsonCache.get(path);
+  }
+
+  getMemoryUsage() {
+    return {
+      images: this.imageCache.size,
+      audio: this.audioCache.size,
+      json: this.jsonCache.size,
+    };
+  }
+
+  clearCaches() {
+    this.imageCache.clear();
+    this.audioCache.forEach(a => {
+      if (a instanceof HTMLAudioElement) {
+        a.pause();
+        a.src = '';
+      }
+    });
+    this.audioCache.clear();
+    this.jsonCache.clear();
   }
 }
 

--- a/src/world/TileEngine.js
+++ b/src/world/TileEngine.js
@@ -1,25 +1,56 @@
 import MapManager from './MapManager.js';
+import AssetLoader from '../core/AssetLoader.js';
 
 class TileEngine {
-  constructor(ctx) {
+  constructor(ctx, tileSize = 16) {
     this.ctx = ctx;
+    this.tileSize = tileSize;
     this.camera = { x: 0, y: 0 };
+    this.viewport = {
+      width: ctx.canvas?.width || 0,
+      height: ctx.canvas?.height || 0,
+    };
+  }
+
+  updateViewport(width, height) {
+    this.viewport.width = width;
+    this.viewport.height = height;
   }
 
   drawLayer(layer) {
-    const tileSize = 16;
+    const tileSize = this.tileSize;
     const tileset = MapManager.current.tilesets[0];
-    const image = document.createElement('img');
-    image.src = tileset.image; // assume loaded elsewhere
+    let image = AssetLoader.getImage(tileset.image);
+    if (!image) {
+      // Start loading and skip rendering this frame
+      AssetLoader.loadImages([tileset.image]);
+      return;
+    }
+
     const cols = tileset.columns;
-    for (let y = 0; y < layer.height; y++) {
-      for (let x = 0; x < layer.width; x++) {
+    const startCol = Math.max(Math.floor(this.camera.x / tileSize), 0);
+    const endCol = Math.min(Math.ceil((this.camera.x + this.viewport.width) / tileSize), layer.width);
+    const startRow = Math.max(Math.floor(this.camera.y / tileSize), 0);
+    const endRow = Math.min(Math.ceil((this.camera.y + this.viewport.height) / tileSize), layer.height);
+
+    for (let y = startRow; y < endRow; y++) {
+      for (let x = startCol; x < endCol; x++) {
         const index = y * layer.width + x;
         const id = layer.data[index];
         if (id === 0) continue;
         const sx = ((id - 1) % cols) * tileSize;
         const sy = Math.floor((id - 1) / cols) * tileSize;
-        this.ctx.drawImage(image, sx, sy, tileSize, tileSize, x * tileSize - this.camera.x, y * tileSize - this.camera.y, tileSize, tileSize);
+        this.ctx.drawImage(
+          image,
+          sx,
+          sy,
+          tileSize,
+          tileSize,
+          x * tileSize - this.camera.x,
+          y * tileSize - this.camera.y,
+          tileSize,
+          tileSize,
+        );
       }
     }
   }
@@ -29,8 +60,8 @@ class TileEngine {
   }
 
   centerOn(x, y) {
-    this.camera.x = x - 120; // half of 240
-    this.camera.y = y - 80;  // half of 160
+    this.camera.x = x - this.viewport.width / 2;
+    this.camera.y = y - this.viewport.height / 2;
   }
 }
 


### PR DESCRIPTION
## Summary
- enforce configurable cache limits with eviction in AssetLoader
- add memory usage helpers and cache clearing
- implement viewport-aware tile rendering that uses cached tileset images

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm start` *(fails: ReferenceError: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68c6c9947e38832da2b68187b34fdd43