### PR TITLE
Add initial Overworld scene

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,11 +1,15 @@
 import GameEngine from './src/core/GameEngine.js';
+import SceneManager from './src/scenes/SceneManager.js';
+import OverworldScene from './src/scenes/OverworldScene.js';
 
 const game = new GameEngine();
+SceneManager.registerScene('Overworld', OverworldScene);
 
 const assetManifest = {};
 
 async function main() {
   await game.start(assetManifest);
+  SceneManager.switchTo('Overworld');
 }
 
 main();

--- a/src/scenes/OverworldScene.js
+++ b/src/scenes/OverworldScene.js
@@ -1,0 +1,16 @@
+import Scene from './Scene.js';
+
+class OverworldScene extends Scene {
+  render(ctx) {
+    ctx.fillStyle = '#3a854a';
+    ctx.fillRect(0, 0, ctx.canvas.width, ctx.canvas.height);
+
+    ctx.fillStyle = '#fff';
+    ctx.font = '16px sans-serif';
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.fillText('Overworld Scene Loaded!', ctx.canvas.width / 2, ctx.canvas.height / 2);
+  }
+}
+
+export default OverworldScene;


### PR DESCRIPTION
## Summary
- add Overworld scene rendering a green background and text
- load the Overworld scene on startup by registering it with the SceneManager

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c6cf5459f4832dbc534c54b35f34b5