### PR TITLE
feat: implement dynamic sprite loading

### DIFF
--- a/src/characters/NPCManager.js
+++ b/src/characters/NPCManager.js
@@ -5,9 +5,9 @@ import { DialogueComponent, LessonComponent, PatrolComponent } from './component
 const TILE_SIZE = 16;
 
 class NPC {
-  constructor(def, index) {
+  constructor(def, index, sprite) {
     this.pos = { x: def.x, y: def.y };
-    this.color = def.color || `hsl(${(index * 67) % 360},60%,50%)`;
+    this.sprite = sprite;
     this.components = [];
     if (def.dialogue) this.components.push(new DialogueComponent(def.dialogue));
     if (def.lesson) this.components.push(new LessonComponent(def.lesson));
@@ -19,8 +19,18 @@ class NPC {
   }
 
   render(ctx) {
-    ctx.fillStyle = this.color;
-    ctx.fillRect(this.pos.x * TILE_SIZE, this.pos.y * TILE_SIZE, TILE_SIZE, TILE_SIZE);
+    if (!this.sprite) return;
+    ctx.drawImage(
+      this.sprite,
+      0,
+      0,
+      TILE_SIZE,
+      TILE_SIZE,
+      this.pos.x * TILE_SIZE,
+      this.pos.y * TILE_SIZE,
+      TILE_SIZE,
+      TILE_SIZE
+    );
   }
 }
 
@@ -29,8 +39,8 @@ class NPCManager {
     this.npcs = [];
   }
 
-  load(defs) {
-    this.npcs = defs.map((d, i) => new NPC(d, i));
+  load(defs, sprite) {
+    this.npcs = defs.map((d, i) => new NPC(d, i, sprite));
   }
 
   update(dt) {

--- a/src/characters/PlayerController.js
+++ b/src/characters/PlayerController.js
@@ -1,4 +1,5 @@
 import { Events } from '../events/EventManager.js';
+import SpriteAnimator from '../graphics/SpriteAnimator.js';
 
 const TILE_SIZE = 16;
 const MOVE_TIME = 0.18; // seconds per tile
@@ -9,13 +10,13 @@ const MOVE_TIME = 0.18; // seconds per tile
 class PlayerController {
   /**
    * @param {import('../world/CollisionSystem.js').default} collisionSystem
-   * @param {import('../graphics/SpriteAnimator.js').default} animator
+   * @param {HTMLImageElement} spriteSheet
    * @param {any} input
    * @param {import('../events/EventManager.js').default} eventManager
    */
-  constructor(collisionSystem, animator, input, eventManager) {
+  constructor(collisionSystem, spriteSheet, input, eventManager) {
     this.collisionSystem = collisionSystem;
-    this.animator = animator;
+    this.animator = new SpriteAnimator(spriteSheet);
     this.input = input;
     this.eventManager = eventManager;
 
@@ -110,26 +111,20 @@ class PlayerController {
   render(ctx) {
     const px = this.moving ? this.pixelPos.x : this.gridPos.x * TILE_SIZE;
     const py = this.moving ? this.pixelPos.y : this.gridPos.y * TILE_SIZE;
-    if (this.animator && this.animator.sprite) {
-      const frame = this.animator.frame;
-      const dirRow = { down: 0, left: 1, right: 2, up: 3 }[this.direction];
-      ctx.drawImage(
-        this.animator.sprite,
-        frame * TILE_SIZE,
-        dirRow * TILE_SIZE,
-        TILE_SIZE,
-        TILE_SIZE,
-        px,
-        py,
-        TILE_SIZE,
-        TILE_SIZE
-      );
-    } else {
-      // Placeholder player rectangle
-      ctx.fillStyle = 'blue';
-      const size = TILE_SIZE * 2;
-      ctx.fillRect(px, py - (size - TILE_SIZE), size, size);
-    }
+    if (!this.animator || !this.animator.sprite) return;
+    const frame = this.animator.frame;
+    const dirRow = { down: 0, left: 1, right: 2, up: 3 }[this.direction];
+    ctx.drawImage(
+      this.animator.sprite,
+      frame * TILE_SIZE,
+      dirRow * TILE_SIZE,
+      TILE_SIZE,
+      TILE_SIZE,
+      px,
+      py,
+      TILE_SIZE,
+      TILE_SIZE
+    );
   }
 }
 


### PR DESCRIPTION
## Summary
- dynamically load map tileset, player, and NPC sprites when entering the overworld
- draw player and NPCs using sprite sheets instead of placeholder rectangles

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c6d8755198832d93528c5f0a5b5069