### PR TITLE
Add interaction prompts and Basque-themed HUD

### DIFF
--- a/src/characters/PlayerController.js
+++ b/src/characters/PlayerController.js
@@ -47,6 +47,20 @@ class PlayerController {
     this.pending.push(dir);
   }
 
+  /**
+   * Compute the tile coordinates directly in front of the player.
+   * This helps interaction systems know which NPC or object is being
+   * faced without duplicating direction math elsewhere.
+   */
+  getFacingPos() {
+    const front = { x: this.gridPos.x, y: this.gridPos.y };
+    if (this.direction === 'up') front.y -= 1;
+    if (this.direction === 'down') front.y += 1;
+    if (this.direction === 'left') front.x -= 1;
+    if (this.direction === 'right') front.x += 1;
+    return front;
+  }
+
   _tryStartMove(dir) {
     const delta = { x: 0, y: 0 };
     if (dir === 'up') delta.y = -1;

--- a/src/core/InputHandler.js
+++ b/src/core/InputHandler.js
@@ -11,7 +11,9 @@ const KEY_TO_DIR = {
   d: 'right'
 };
 
-const ACTION_KEYS = ['Enter'];
+// Include Space so players can interact with NPCs using the classic
+// Pokémon control scheme.
+const ACTION_KEYS = ['Enter', ' '];
 const CANCEL_KEYS = ['Escape'];
 
 export default class InputHandler {

--- a/src/dialogue/DialogueSystem.js
+++ b/src/dialogue/DialogueSystem.js
@@ -1,0 +1,24 @@
+import DialogueEngine from './DialogueEngine.js';
+
+// Lightweight facade around the existing DialogueEngine. This keeps
+// the scene code decoupled from the underlying implementation and makes
+// it easier to expand with tutorials or quizzes later.
+class DialogueSystem {
+  start(id) {
+    DialogueEngine.startDialogue(id);
+  }
+
+  update(dt) {
+    DialogueEngine.update(dt);
+  }
+
+  render(ctx) {
+    DialogueEngine.render(ctx);
+  }
+
+  isActive() {
+    return !!DialogueEngine.script;
+  }
+}
+
+export default new DialogueSystem();

--- a/src/ui/HUD.js
+++ b/src/ui/HUD.js
@@ -9,9 +9,21 @@ class HUD {
   }
 
   render(ctx) {
-    ctx.fillStyle = '#fff';
-    ctx.fillText('XP: ' + ProgressService.data.xp, 5, 10);
-    if (this.lesson) ctx.fillText('Word: ' + this.lesson, 5, 20);
+    // Basque flag inspired banner
+    ctx.save();
+    const w = 70;
+    ctx.fillStyle = '#d50000'; // red
+    ctx.fillRect(2, 2, w, 6);
+    ctx.fillStyle = '#ffffff';
+    ctx.fillRect(2, 8, w, 6);
+    ctx.fillStyle = '#007a3d'; // green
+    ctx.fillRect(2, 14, w, 6);
+
+    ctx.fillStyle = '#000';
+    ctx.font = '10px monospace';
+    ctx.fillText('XP: ' + ProgressService.data.xp, 5, 28);
+    if (this.lesson) ctx.fillText('Word: ' + this.lesson, 5, 38);
+    ctx.restore();
   }
 }
 

--- a/src/ui/UIManager.js
+++ b/src/ui/UIManager.js
@@ -1,0 +1,38 @@
+import hud from './HUD.js';
+
+/**
+ * Central place to render HUD elements and temporary prompts such as
+ * interaction indicators. Rendering is kept simple to avoid impacting
+ * frame rate.
+ */
+class UIManager {
+  constructor() {
+    this.prompt = null; // {text, x, y}
+  }
+
+  /** Show an on-screen prompt above world elements. */
+  showPrompt(text, x, y) {
+    this.prompt = { text, x, y };
+  }
+
+  hidePrompt() {
+    this.prompt = null;
+  }
+
+  render(ctx) {
+    // Basic HUD (XP, current word, Basque-themed flag bar)
+    hud.render(ctx);
+
+    if (this.prompt) {
+      const { text, x, y } = this.prompt;
+      ctx.fillStyle = 'yellow';
+      ctx.font = '10px monospace';
+      ctx.fillText(text, x, y);
+      // Small sparkle to draw attention
+      ctx.fillRect(x - 2, y - 10, 2, 2);
+      ctx.fillRect(x + ctx.measureText(text).width + 2, y - 10, 2, 2);
+    }
+  }
+}
+
+export default new UIManager();

--- a/src/world/TileEngine.js
+++ b/src/world/TileEngine.js
@@ -10,6 +10,7 @@ class TileEngine {
       width: ctx.canvas?.width || 0,
       height: ctx.canvas?.height || 0,
     };
+    this.labels = [];
   }
 
   updateViewport(width, height) {
@@ -58,6 +59,7 @@ class TileEngine {
 
   render() {
     MapManager.current.layers?.filter(l => l.type === 'tilelayer').forEach(l => this.drawLayer(l));
+    this._drawLabels();
     this._drawCollisionDebug();
     this._drawGrid();
   }
@@ -65,6 +67,26 @@ class TileEngine {
   centerOn(x, y) {
     this.camera.x = x - this.viewport.width / 2;
     this.camera.y = y - this.viewport.height / 2;
+  }
+
+  setLabels(labels) {
+    this.labels = labels;
+  }
+
+  _drawLabels() {
+    if (!this.labels?.length) return;
+    const tileSize = this.tileSize;
+    this.ctx.font = '10px monospace';
+    this.labels.forEach(l => {
+      const sx = l.x * tileSize - this.camera.x;
+      const sy = l.y * tileSize - this.camera.y - 2;
+      const text = l.text || '';
+      const w = this.ctx.measureText(text).width + 4;
+      this.ctx.fillStyle = 'rgba(255,255,255,0.8)';
+      this.ctx.fillRect(sx - 2, sy - 10, w, 10);
+      this.ctx.fillStyle = '#000';
+      this.ctx.fillText(text, sx, sy - 2);
+    });
   }
 
   _drawCollisionDebug() {


### PR DESCRIPTION
## Summary
- Allow SPACE key as an action button and expose player's facing tile for interaction logic
- Add prompt system and Basque-flag inspired HUD through new UI manager
- Support vocabulary labels on tiles and NPC interaction dialog facade

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c6d7ca4838832d9bbdaec37f737075