### PR TITLE
feat: add player interaction system

### DIFF
--- a/src/characters/NPCManager.js
+++ b/src/characters/NPCManager.js
@@ -1,5 +1,3 @@
-import EventManager, { Events } from '../events/EventManager.js';
-import DialogueEngine from '../dialogue/DialogueEngine.js';
 import { DialogueComponent, LessonComponent, PatrolComponent } from './components/NPCComponent.js';
 
 const TILE_SIZE = 16;
@@ -8,8 +6,11 @@ class NPC {
   constructor(def, index, sprite) {
     this.pos = { x: def.x, y: def.y };
     this.sprite = sprite;
+    this.dialogueId = def.dialogueId || def.dialogue || null;
     this.components = [];
-    if (def.dialogue) this.components.push(new DialogueComponent(def.dialogue));
+    if (def.dialogueId || def.dialogue) {
+      this.components.push(new DialogueComponent(this.dialogueId));
+    }
     if (def.lesson) this.components.push(new LessonComponent(def.lesson));
     if (def.patrol) this.components.push(new PatrolComponent(def.patrol));
   }
@@ -57,13 +58,13 @@ class NPCManager {
   }
 
   /** Return NPC at grid coordinate */
-  getNPCAt(x, y) {
-    return this.npcs.find(n => n.pos.x === x && n.pos.y === y);
+  getNpcAt(x, y) {
+    return this.npcs.find(n => n.pos.x === x && n.pos.y === y) || null;
   }
 
   /** Trigger NPC at coordinate */
   interactAt(x, y) {
-    const npc = this.getNPCAt(x, y);
+    const npc = this.getNpcAt(x, y);
     npc?.interact();
   }
 
@@ -76,7 +77,7 @@ class NPCManager {
     if (dir === 'left') offset.x = -1;
     if (dir === 'right') offset.x = 1;
     const target = { x: player.gridPos.x + offset.x, y: player.gridPos.y + offset.y };
-    const npc = this.getNPCAt(target.x, target.y);
+    const npc = this.getNpcAt(target.x, target.y);
     if (!npc) return;
     const px = npc.pos.x * TILE_SIZE;
     const py = npc.pos.y * TILE_SIZE;

--- a/src/characters/PlayerController.js
+++ b/src/characters/PlayerController.js
@@ -122,15 +122,22 @@ class PlayerController {
 
   /** Interact with NPC in front of the player */
   interact() {
-    if (!this.npcManager) return;
+    if (!this.enabled || !this.npcManager) return;
+
     const offset = { x: 0, y: 0 };
     if (this.direction === 'up') offset.y = -1;
     if (this.direction === 'down') offset.y = 1;
     if (this.direction === 'left') offset.x = -1;
     if (this.direction === 'right') offset.x = 1;
-    const target = { x: this.gridPos.x + offset.x, y: this.gridPos.y + offset.y };
-    this.npcManager.interactAt(target.x, target.y);
-    AudioManager.playSound('interact');
+
+    const targetX = this.gridPos.x + offset.x;
+    const targetY = this.gridPos.y + offset.y;
+    const npc = this.npcManager.getNpcAt(targetX, targetY);
+
+    if (npc && npc.dialogueId) {
+      this.eventManager.emit(Events.DIALOGUE_STARTED, { id: npc.dialogueId });
+      AudioManager.playSound('interact');
+    }
   }
 
   render(ctx) {

--- a/src/dialogue/DialogueEngine.js
+++ b/src/dialogue/DialogueEngine.js
@@ -13,6 +13,7 @@ class DialogueEngine {
     this.activeId = null;
 
     EventManager.subscribe(Events.INPUT_ACTION_PRESS, () => this.advance());
+    EventManager.subscribe(Events.DIALOGUE_STARTED, e => this.startDialogue(e.id));
   }
 
   startDialogue(dialogueId) {
@@ -22,7 +23,6 @@ class DialogueEngine {
     this.script = Array.isArray(dialogue) ? dialogue : dialogue.lines;
     this.page = 0;
     this._showPage();
-    EventManager.emit(Events.DIALOGUE_STARTED, { id: dialogueId });
   }
 
   _showPage() {

--- a/src/dialogue/DialogueSystem.js
+++ b/src/dialogue/DialogueSystem.js
@@ -1,11 +1,3 @@
-import EventManager, { Events } from '../events/EventManager.js';
-import DialogueEngine from './DialogueEngine.js';
-
-// Connects event-driven dialogue triggers with the DialogueEngine
-class DialogueSystem {
-  constructor() {
-    EventManager.subscribe(Events.DIALOGUE_STARTED, e => DialogueEngine.startDialogue(e.id));
-  }
-}
-
-export default new DialogueSystem();
+// Legacy system retained for compatibility; dialogue events are now
+// handled directly within DialogueEngine.
+export default {};


### PR DESCRIPTION
## Summary
- add `interact` method for player to trigger dialogues when facing NPCs
- track NPC dialogue IDs and expose `getNpcAt` lookup
- start dialogue engine in response to `DIALOGUE_STARTED` events

## Testing
- `npm test` (fails: Missing script "test")


------
https://chatgpt.com/codex/tasks/task_e_68c6dbcc0954832da12c29b477a064d5