### PR TITLE
Trigger quiz after dialogue

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,9 +1,11 @@
 import GameEngine from './src/core/GameEngine.js';
 import SceneManager from './src/scenes/SceneManager.js';
 import OverworldScene from './src/scenes/OverworldScene.js';
+import VocabularyQuizScene from './src/scenes/VocabularyQuizScene.js';
 
 const game = new GameEngine();
 SceneManager.registerScene('Overworld', OverworldScene);
+SceneManager.registerScene('VocabularyQuizScene', VocabularyQuizScene);
 
 const assetManifest = {};
 

--- a/public/dialogues/dialogue_quizmaster.json
+++ b/public/dialogues/dialogue_quizmaster.json
@@ -1,0 +1,5 @@
+{
+  "QUIZ_GIVER_INTRO": [
+    { "euskera": "Kaixo! Probatu zure hiztegia?", "translation": "Hello! Want to test your vocabulary?" }
+  ]
+}

--- a/public/maps/entrance_hall.json
+++ b/public/maps/entrance_hall.json
@@ -599,6 +599,27 @@
               "value": 8
             }
           ]
+        },
+        {
+          "id": 4,
+          "name": "Quiz Master",
+          "type": "npc",
+          "x": 96,
+          "y": 128,
+          "width": 32,
+          "height": 32,
+          "properties": [
+            {
+              "name": "dialogueId",
+              "type": "string",
+              "value": "QUIZ_GIVER_INTRO"
+            },
+            {
+              "name": "quizId",
+              "type": "string",
+              "value": "VOCAB_QUIZ_1"
+            }
+          ]
         }
       ]
     }

--- a/src/scenes/OverworldScene.js
+++ b/src/scenes/OverworldScene.js
@@ -5,11 +5,12 @@ import PlayerController from '../characters/PlayerController.js';
 import CollisionSystem from '../world/CollisionSystem.js';
 import InputHandler from '../core/InputHandler.js';
 import AssetLoader from '../core/AssetLoader.js';
-import EventManager from '../events/EventManager.js';
+import EventManager, { Events } from '../events/EventManager.js';
 import NPCManager from '../characters/NPCManager.js';
 import DialogueEngine from '../dialogue/DialogueEngine.js';
 import UIManager from '../ui/UIManager.js';
 import '../dialogue/DialogueSystem.js';
+import SceneManager from './SceneManager.js';
 
 class OverworldScene extends Scene {
   constructor() {
@@ -26,9 +27,11 @@ class OverworldScene extends Scene {
     this.dialogueEngine = DialogueEngine;
     this.ui = UIManager;
     this.fps = 0;
+    this.onDialogueFinished = this.onDialogueFinished.bind(this);
   }
 
   async onEnter(data) {
+    EventManager.subscribe(Events.DIALOGUE_FINISHED, this.onDialogueFinished);
     const map = await this.mapManager.load('entrance_hall', 'public/maps/entrance_hall.json');
     const tileset = map.tilesets?.[0];
     const tilesetPath = tileset ? `public/assets/tilesets/${tileset.image}` : null;
@@ -76,6 +79,16 @@ class OverworldScene extends Scene {
     this.npcManager.load(npcDefs, receptionistSprite);
 
     this.input.start();
+  }
+
+  onDialogueFinished(e) {
+    if (e.id === 'QUIZ_GIVER_INTRO') {
+      SceneManager.switchTo('VocabularyQuizScene', { quizId: 'VOCAB_QUIZ_1' });
+    }
+  }
+
+  onExit() {
+    EventManager.unsubscribe(Events.DIALOGUE_FINISHED, this.onDialogueFinished);
   }
 
   update(dt) {

--- a/src/scenes/VocabularyQuizScene.js
+++ b/src/scenes/VocabularyQuizScene.js
@@ -41,7 +41,7 @@ class VocabularyQuizScene extends Scene {
     this.quizSystem.submitAnswer(this.selectedIndex);
     if (!this.quizSystem.active) {
       this._cleanup();
-      SceneManager.switchTo('OverworldScene');
+      SceneManager.switchTo('Overworld');
     } else {
       this.selectedIndex = 0;
     }


### PR DESCRIPTION
## Summary
- Add Quiz Master NPC to entrance hall map with dialogue and quiz mapping.
- Launch vocabulary quiz after Quiz Master dialogue ends in OverworldScene, with cleanup on exit.
- Register VocabularyQuizScene and ensure quiz scene returns player to the overworld.

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c6dce417b8832db999ca2c717d7532