### PR TITLE
feat: connect NPC interactions to vocabulary quiz

### DIFF
--- a/src/characters/NPCManager.js
+++ b/src/characters/NPCManager.js
@@ -7,6 +7,7 @@ class NPC {
     this.pos = { x: def.x, y: def.y };
     this.sprite = sprite;
     this.dialogueId = def.dialogueId || def.dialogue || null;
+    this.quizId = def.quizId || null;
     this.components = [];
     if (def.dialogueId || def.dialogue) {
       this.components.push(new DialogueComponent(this.dialogueId));

--- a/src/scenes/OverworldScene.js
+++ b/src/scenes/OverworldScene.js
@@ -73,6 +73,7 @@ class OverworldScene extends Scene {
           x: o.x / tileSize,
           y: o.y / tileSize,
           dialogue: props.dialogueId,
+          quizId: props.quizId,
         };
       });
     const receptionistSprite = AssetLoader.getImage(receptionistPath);
@@ -82,8 +83,11 @@ class OverworldScene extends Scene {
   }
 
   onDialogueFinished(e) {
-    if (e.id === 'QUIZ_GIVER_INTRO') {
-      SceneManager.switchTo('VocabularyQuizScene', { quizId: 'VOCAB_QUIZ_1' });
+    const npc = this.npcManager.npcs?.find(
+      n => n.dialogueId === e.id && n.quizId,
+    );
+    if (npc) {
+      SceneManager.switchTo('VocabularyQuizScene', { quizId: npc.quizId });
     }
   }
 


### PR DESCRIPTION
## Summary
- map quiz NPC definitions to quiz IDs in Overworld
- trigger VocabularyQuizScene based on NPC quiz metadata

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68c6de200a8c832d930e84f259a83987