### PR TITLE
Add Basque dialogues and interactive board

### DIFF
--- a/public/dialogues/dialogue_board.json
+++ b/public/dialogues/dialogue_board.json
@@ -1,0 +1,6 @@
+{
+  "ANNOUNCEMENTS_BOARD": [
+    { "euskera": "Irakurri taula!", "translation": "Read the board!" },
+    { "euskera": "Gaurko hitza: 'eskola'", "translation": "Word of the day: 'school'" }
+  ]
+}

--- a/public/dialogues/dialogue_receptionist.json
+++ b/public/dialogues/dialogue_receptionist.json
@@ -1,5 +1,6 @@
 {
   "RECEPTIONIST_GREETING": [
+    { "euskera": "Kaixo!", "translation": "Hello!" },
     { "euskera": "Ongi etorri Euskal Ikastetxera!", "translation": "Welcome to the Basque School!" },
     { "euskera": "Hemen nago laguntzeko.", "translation": "I am here to help." },
     { "euskera": "Lehenengo gelara joan zaitezke.", "translation": "You can go to the first classroom." }

--- a/src/characters/NPCManager.js
+++ b/src/characters/NPCManager.js
@@ -46,8 +46,8 @@ class NPCManager {
     this.npcs = [];
   }
 
-  load(defs, sprite) {
-    this.npcs = defs.map((d, i) => new NPC(d, i, sprite));
+  load(defs, defaultSprite) {
+    this.npcs = defs.map((d, i) => new NPC(d, i, d.sprite || defaultSprite));
   }
 
   update(dt) {

--- a/src/education/ContentDatabase.js
+++ b/src/education/ContentDatabase.js
@@ -26,7 +26,14 @@ class ContentDatabase {
           });
           break;
         case 'dialogue':
-          this.dialogues.set(m.key, data);
+          if (m.key) {
+            const lines = data[m.key] || data.lines || data;
+            this.dialogues.set(m.key, lines);
+          } else {
+            Object.entries(data).forEach(([key, lines]) => {
+              this.dialogues.set(key, lines);
+            });
+          }
           break;
         case 'quiz':
           this.quizzes.set(m.key, data);

--- a/src/scenes/OverworldScene.js
+++ b/src/scenes/OverworldScene.js
@@ -11,6 +11,7 @@ import DialogueEngine from '../dialogue/DialogueEngine.js';
 import UIManager from '../ui/UIManager.js';
 import '../dialogue/DialogueSystem.js';
 import SceneManager from './SceneManager.js';
+import ContentDatabase from '../education/ContentDatabase.js';
 
 class OverworldScene extends Scene {
   constructor() {
@@ -43,6 +44,12 @@ class OverworldScene extends Scene {
     if (tilesetPath) imagesToLoad.unshift(tilesetPath);
     await AssetLoader.loadImages(imagesToLoad);
 
+    await ContentDatabase.load([
+      { type: 'dialogue', src: 'public/dialogues/dialogue_receptionist.json' },
+      { type: 'dialogue', src: 'public/dialogues/dialogue_quizmaster.json' },
+      { type: 'dialogue', src: 'public/dialogues/dialogue_board.json' },
+    ]);
+
     if (tileset) {
       this.tileEngine.tileSize = tileset.tilewidth || map.tilewidth || this.tileEngine.tileSize;
       const img = AssetLoader.getImage(tilesetPath);
@@ -64,8 +71,9 @@ class OverworldScene extends Scene {
 
     const objectLayer = map.layers?.find(l => l.type === 'objectgroup');
     const tileSize = map.tilewidth || this.tileEngine.tileSize;
+    const boardSprite = AssetLoader.createPlaceholder('board_sprite', 16, 16, 'green');
     const npcDefs = (objectLayer?.objects || [])
-      .filter(o => o.type === 'npc')
+      .filter(o => o.type === 'npc' || o.type === 'interactable')
       .map(o => {
         const props = {};
         (o.properties || []).forEach(p => (props[p.name] = p.value));
@@ -74,6 +82,7 @@ class OverworldScene extends Scene {
           y: o.y / tileSize,
           dialogue: props.dialogueId,
           quizId: props.quizId,
+          sprite: o.type === 'interactable' ? boardSprite : null,
         };
       });
     const receptionistSprite = AssetLoader.getImage(receptionistPath);

--- a/src/ui/HUD.js
+++ b/src/ui/HUD.js
@@ -10,7 +10,8 @@ class HUD {
 
   render(ctx) {
     ctx.fillStyle = '#fff';
-    ctx.fillText('XP: ' + ProgressService.data.xp, 5, 10);
+    const prog = ProgressService.data;
+    ctx.fillText('Lvl ' + prog.level + ' XP: ' + prog.xp, 5, 10);
     if (this.lesson) ctx.fillText('Word: ' + this.lesson, 5, 20);
   }
 }


### PR DESCRIPTION
## Summary
- load dialogue JSON files into the content database
- allow NPC manager to assign custom sprites and include bulletin board
- show player level and XP in HUD

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c6dee99cbc832db4d728bfbecdbef0